### PR TITLE
Add role name template replacement to README

### DIFF
--- a/README.md.j2
+++ b/README.md.j2
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/oasis-roles/{{ role_name }}.svg?branch=master)](https://travis-ci.org/oasis-roles/{{ role_name }})
 
-ROLE NAME
+{{ role_name }}
 ===========
 
 Basic description for {{ role_name }}


### PR DESCRIPTION
I think we forget to set the role name in almost every new role we make,
so it seems reasonable to include this in the template.