### PR TITLE
Update default travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 versions:
   - "2.7"
-  - "3.5"
+  - "3.7"
 cache: pip
 sudo: required
 services:
@@ -18,9 +18,11 @@ install:
   - molecule --version
 
 script:
+  # every scenario with a converge playbook should be linted
   - molecule lint -s openstack
-  - molecule test -s docker
+  # flake8 is not guaranteed to run on lint, do that before testing
   - flake8 $(find . -name '*.py')
+  - molecule test -s docker
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ versions:
   - "2.7"
   - "3.7"
 cache: pip
-sudo: required
 services:
   - docker
 


### PR DESCRIPTION
- molecule does not support python 3.5
- `molecule test` runs lint first, and lint lints the entire role,
  not just the targeted scenario, so the first lint appears to be
  redundant