### PR TITLE
Fix default tests, tidy up molecule

### DIFF
--- a/molecule/docker/molecule.yml.j2
+++ b/molecule/docker/molecule.yml.j2
@@ -22,8 +22,6 @@ provisioner:
   playbooks:
     prepare: ../shared/prepare.yml
     converge: ../shared/playbook.yml
-scenario:
-  name: docker
 verifier:
   name: testinfra
   options:
@@ -36,4 +34,4 @@ verifier:
   # but is not a requirement. For scenario specific tests, add the appropriate
   # file path to the test or test directory below
   additional_files_or_dirs:
-    - ../shared/*
+    - ../../shared/tests

--- a/molecule/docker/tests/test_null.py
+++ b/molecule/docker/tests/test_null.py
@@ -1,0 +1,8 @@
+# Without at least a file here, tests in the additional directory will not
+# get picked up. If you add actual tests to this directory, then you can
+# safely eliminate this file. Otherwise, it exists only to cause the tests in
+# shared/tests to be discovered.
+#
+# Most tests should be written in the shared/tests directory so that they can
+# be captured by all the scenarios. Only add tests here if there are tests
+# only relevant to a particular scenario

--- a/molecule/openstack/molecule.yml.j2
+++ b/molecule/openstack/molecule.yml.j2
@@ -15,8 +15,6 @@ provisioner:
   playbooks:
     prepare: ../shared/prepare.yml
     converge: ../shared/playbook.yml
-scenario:
-  name: openstack
 verifier:
   name: testinfra
   options:
@@ -29,4 +27,4 @@ verifier:
   # but is not a requirement. For scenario specific tests, add the appropriate
   # file path to the test or test directory below
   additional_files_or_dirs:
-    - ../shared/*
+    - ../../shared/tests

--- a/molecule/openstack/tests/test_null.py
+++ b/molecule/openstack/tests/test_null.py
@@ -1,0 +1,8 @@
+# Without at least a file here, tests in the additional directory will not
+# get picked up. If you add actual tests to this directory, then you can
+# safely eliminate this file. Otherwise, it exists only to cause the tests in
+# shared/tests to be discovered.
+#
+# Most tests should be written in the shared/tests directory so that they can
+# be captured by all the scenarios. Only add tests here if there are tests
+# only relevant to a particular scenario


### PR DESCRIPTION
Begin some of the deduplication of molecule.yml available in Molecule
2.20
Fix the shared tests directory. It should be relative to the scenario's
"tests" directory and not to the scenario directory itself. Also, you
have to have at least an empty test_\*.py file in the scenario's specific
tests directory before additional dirs are picked up. So now that is a
thing. Also, adding "\*" would cause the test runner to try and pick up
the yaml files and others in that directory for testing. And that
doens't work really well.